### PR TITLE
fix/feat: automatically generation nonce values, exclude empty var fields, disable image digest validation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "canonical-json": "0.0.4",
     "debug": "^3.1.0",
-    "docker-registry-client": "^3.3.0",
     "fs-extra": "^6.0.1",
     "jsen": "^0.6.6",
     "thirty-two": "^1.0.2"

--- a/schemas/CodiusVarsSpec.json
+++ b/schemas/CodiusVarsSpec.json
@@ -27,17 +27,11 @@
           "additionalProperties":{
             "type":"object",
             "properties":{
-              "nonce":{
-                "type":"string"
-              },
               "value":{
                 "type":"string"
               }
             },
-            "required":[
-              "nonce",
-              "value"
-            ],
+            "required":[ "value" ],
             "additionalProperties":false
           }
         },

--- a/src/generate-manifest.js
+++ b/src/generate-manifest.js
@@ -30,7 +30,10 @@ const generateManifest = async function (codiusVarsPath, codiusPath, options = {
   debug('validating generated manifest...')
   validateFinalManifest(generatedManifest)
 
-  // Optionally add an empty private vars field
+  // Automatically add an empty private vars field to the final manifest.
+  // Codiusd will reject contract uploads that have public
+  // vars defined but no private manifest field, although the latter is optional
+  // See codiusd issue #75: https://github.com/codius/codiusd/issues/75
   if (options.addEmptyPrivateVars) {
     const publicVars = generatedManifest['manifest']['vars']
     const privateVars = generatedManifest['manifest']['private']

--- a/src/generate-manifest.js
+++ b/src/generate-manifest.js
@@ -7,7 +7,7 @@ const jsen = require('jsen')
 const { validateGeneratedManifest } = require('./validate-generated-manifest.js')
 // const drc = require('docker-registry-client')
 
-const generateManifest = async function (codiusVarsPath, codiusPath) {
+const generateManifest = async function (codiusVarsPath, codiusPath, options = {}) {
   const codiusVars = await fse.readJson(codiusVarsPath)
   const codius = await fse.readJson(codiusPath)
 
@@ -30,6 +30,14 @@ const generateManifest = async function (codiusVarsPath, codiusPath) {
   debug('validating generated manifest...')
   validateFinalManifest(generatedManifest)
 
+  // Optionally add an empty private vars field
+  if (options.addEmptyPrivateVars) {
+    const publicVars = generatedManifest['manifest']['vars']
+    const privateVars = generatedManifest['manifest']['private']
+    if (publicVars && !privateVars) {
+      generatedManifest['private'] = {}
+    }
+  }
   /**
   // Validate the digest of each container image
   debug('validating image digest...')

--- a/src/generate-manifest.js
+++ b/src/generate-manifest.js
@@ -7,7 +7,7 @@ const jsen = require('jsen')
 const { validateGeneratedManifest } = require('./validate-generated-manifest.js')
 // const drc = require('docker-registry-client')
 
-const generateManifest = async function (codiusVarsPath, codiusPath, options = {}) {
+const generateManifest = async function (codiusVarsPath, codiusPath) {
   const codiusVars = await fse.readJson(codiusVarsPath)
   const codius = await fse.readJson(codiusPath)
 
@@ -34,13 +34,12 @@ const generateManifest = async function (codiusVarsPath, codiusPath, options = {
   // Codiusd will reject contract uploads that have public
   // vars defined but no private manifest field, although the latter is optional
   // See codiusd issue #75: https://github.com/codius/codiusd/issues/75
-  if (options.addEmptyPrivateVars) {
-    const publicVars = generatedManifest['manifest']['vars']
-    const privateVars = generatedManifest['manifest']['private']
-    if (publicVars && !privateVars) {
-      generatedManifest['private'] = {}
-    }
+  const publicVars = generatedManifest['manifest']['vars']
+  const privateVars = generatedManifest['private']
+  if (publicVars && !privateVars) {
+    generatedManifest['private'] = {}
   }
+
   /**
   // Validate the digest of each container image
   debug('validating image digest...')

--- a/src/validate-containers.js
+++ b/src/validate-containers.js
@@ -12,10 +12,10 @@ const validateContainers = function (manifest) {
   // Validate environment of each container
   for (let i = 0; i < containers.length; i++) {
     const environment = manifest['manifest']['containers'][i]['environment']
-    debug('environment:')
-    debug(environment)
+    debug(`environment: ${JSON.stringify(environment, null, 2)}`)
     // Error check each environment key
-    Object.keys(environment).map((varName) => {
+    const environmentKeys = Object.keys(environment)
+    environmentKeys.map((varName) => {
       const varPath = `manifest.containers[${i}].environment.${varName}`
 
       // Check if env variable name begins with `CODIUS`
@@ -55,6 +55,11 @@ const validateContainers = function (manifest) {
         return
       }
 
+      // Check if private manifest is defined
+      if (!privateManifest) {
+        return
+      }
+
       // Check if environment variable with encoding is defined within private manifest
       const encoding = publicVars[envValue]['encoding']
       const privateVarSpec = privateManifest['vars'] && privateManifest['vars'][envValue]
@@ -66,7 +71,7 @@ const validateContainers = function (manifest) {
           )
         }
       } else if (encoding) {
-        // add error if encoding id defined but not equal to private:sha256
+        // Add error if encoding id is defined but not equal to private:sha256
         addErrorMessage(errors, `manifest.vars.${envValue}`, 'invalid encoding')
       }
     })
@@ -76,6 +81,7 @@ const validateContainers = function (manifest) {
 }
 
 const checkIds = function (containers) {
+  // Check for duplicate container ids
   const errors = []
   const ids = new Set()
 

--- a/src/validate-private-vars.js
+++ b/src/validate-private-vars.js
@@ -6,13 +6,13 @@ const debug = require('debug')('codius-manifest:validate-privatevars')
 const validatePrivateVars = function (manifest) {
   let errors = []
   debug('validating private variables...')
-  const publicVars = manifest['manifest']['vars']
 
   // Check if private vars are not defined
   if (!manifest['private']) {
     return errors
   }
   // Check if public vars are defined
+  const publicVars = manifest['manifest']['vars']
   if (!publicVars) {
     addErrorMessage(errors, 'private', 'cannot validate private vars' +
       ` - manifest.vars is not defined.`)

--- a/test/generate-manifest.test.js
+++ b/test/generate-manifest.test.js
@@ -114,6 +114,28 @@ describe('Generate Complete Manifest', function () {
     return expect(result).to.eventually.become(newValidManifest)
   })
 
+  it('should add an empty private var field to the final manifest if the addEmptyPrivateVars option is specified and the public vars are not defined', async function () {
+    const manifest = JSON.parse(JSON.stringify(manifestJson))
+    delete manifest['manifest']['vars']['AWS_SECRET_KEY']
+    delete manifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY']
+    delete manifest['private']
+    await fse.writeJson(manifestMock, manifest)
+
+    const vars = JSON.parse(JSON.stringify(varsJson))
+    delete vars['vars']['private']['AWS_SECRET_KEY']
+    await fse.writeJson(varsMock, vars)
+
+    const newValidManifest = JSON.parse(JSON.stringify(validManifest))
+    newValidManifest['private'] = {}
+    delete newValidManifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY']
+    delete newValidManifest['manifest']['vars']['AWS_SECRET_KEY']
+    const options = { addEmptyPrivateVars: true }
+    const result = generateManifest(varsMock, manifestMock, options)
+    return expect(result).to.eventually.become(newValidManifest)
+  }
+
+  )
+
   it('should add public encodings for private vars field even if public vars are not defined in codiusvars', async function () {
     const manifest = JSON.parse(JSON.stringify(manifestJson))
     delete manifest['manifest']['vars']

--- a/test/generate-manifest.test.js
+++ b/test/generate-manifest.test.js
@@ -2,18 +2,28 @@ const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const { expect } = chai
 chai.use(chaiAsPromised)
+const cryptoUtils = require('../src/common/crypto-utils.js')
 const fse = require('fs-extra')
-const { after, beforeEach, describe, it } = require('mocha')
+const { after, before, beforeEach, describe, it } = require('mocha')
 const { generateManifest } = require('../src/generate-manifest.js')
-const validManifest = require('./mocks/manifest.test.json')
+const sinon = require('sinon')
+const validManifestMock = './test/mocks/manifest.test.json'
 const varsStatic = './test/mocks/codiusvars.test.json'
 const varsMock = './test/codiusvars.mock.json'
 const manifestStatic = './test/mocks/codius.test.json'
 const manifestMock = './test/mocks/codius.mock.json'
-const varsJson = fse.readJsonSync(varsStatic)
-const manifestJson = fse.readJsonSync(manifestStatic)
 
 describe('Generate Complete Manifest', function () {
+  let validManifest = fse.readJsonSync(validManifestMock)
+  const varsJson = fse.readJsonSync(varsStatic) // codiusvars.json
+  const manifestJson = fse.readJsonSync(manifestStatic) // codius.json
+
+  before(function () {
+    // Create stub for generateNonce function
+    const stub = sinon.stub(cryptoUtils, 'generateNonce')
+    stub.returns('123450325')
+  })
+
   beforeEach(async function () {
     // Create mocks for codiusvars.json and codius.json
     await fse.writeJson(varsMock, varsJson)
@@ -40,7 +50,7 @@ describe('Generate Complete Manifest', function () {
   })
 
   it('should throw error if codiusvars has schema errors', async function () {
-    const vars = JSON.parse(JSON.stringify(manifestJson))
+    const vars = JSON.parse(JSON.stringify(varsJson))
     delete vars['vars']
     await fse.writeJson(varsMock, vars)
     const result = generateManifest(varsMock, manifestMock)
@@ -63,7 +73,7 @@ describe('Generate Complete Manifest', function () {
     return expect(result).to.eventually.become(validManifest)
   })
 
-  it('should override invalid public encodings for the private vars', async function () {
+  it('should override the public encodings for all private vars', async function () {
     const manifest = JSON.parse(JSON.stringify(manifestJson))
     manifest['manifest']['vars']['AWS_SECRET_KEY'] = {
       'encoding': 'private:sha256',
@@ -83,6 +93,73 @@ describe('Generate Complete Manifest', function () {
     return expect(result).to.eventually.become(validManifest)
   })
 
+  it('should not include manifest.vars and manifest.private in final manifest if codiusvars has empty public and private var fields', async function () {
+    const manifest = JSON.parse(JSON.stringify(manifestJson))
+    delete manifest['manifest']['vars']
+    manifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY'] = 'AWS_SECRET_KEY'
+    manifest['manifest']['containers'][0]['environment']['AWS_ACCESS_KEY'] = 'AWS_ACCESS_KEY'
+    await fse.writeJson(manifestMock, manifest)
+
+    const vars = JSON.parse(JSON.stringify(varsJson))
+    vars['vars']['public'] = {}
+    vars['vars']['private'] = {}
+    await fse.writeJson(varsMock, vars)
+
+    const newValidManifest = JSON.parse(JSON.stringify(validManifest))
+    delete newValidManifest['manifest']['vars']
+    delete newValidManifest['private']
+    newValidManifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY'] = 'AWS_SECRET_KEY'
+    newValidManifest['manifest']['containers'][0]['environment']['AWS_ACCESS_KEY'] = 'AWS_ACCESS_KEY'
+    const result = generateManifest(varsMock, manifestMock)
+    return expect(result).to.eventually.become(newValidManifest)
+  })
+
+  it('should add public encodings for private vars field even if public vars are not defined in codiusvars', async function () {
+    const manifest = JSON.parse(JSON.stringify(manifestJson))
+    delete manifest['manifest']['vars']
+    manifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY'] = '$AWS_SECRET_KEY'
+    manifest['manifest']['containers'][0]['environment']['AWS_ACCESS_KEY'] = 'AWS_ACCESS_KEY'
+    await fse.writeJson(manifestMock, manifest)
+
+    const vars = JSON.parse(JSON.stringify(varsJson))
+    vars['vars']['public'] = {}
+    await fse.writeJson(varsMock, vars)
+
+    const newValidManifest = JSON.parse(JSON.stringify(validManifest))
+    delete newValidManifest['manifest']['vars']['AWS_ACCESS_KEY']
+    newValidManifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY'] = '$AWS_SECRET_KEY'
+    newValidManifest['manifest']['containers'][0]['environment']['AWS_ACCESS_KEY'] = 'AWS_ACCESS_KEY'
+    const result = generateManifest(varsMock, manifestMock)
+    return expect(result).to.eventually.become(newValidManifest)
+  })
+
+  it('should leave out private vars field from final manifest if private vars are not defined in codiusvars', async function () {
+    const manifest = JSON.parse(JSON.stringify(manifestJson))
+    manifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY'] = 'AWS_SECRET_KEY'
+    delete manifest['manifest']['vars']['AWS_SECRET_KEY']
+    await fse.writeJson(manifestMock, manifest)
+
+    const vars = JSON.parse(JSON.stringify(varsJson))
+    vars['vars']['private'] = {}
+    await fse.writeJson(varsMock, vars)
+
+    const newValidManifest = JSON.parse(JSON.stringify(validManifest))
+    delete newValidManifest['manifest']['vars']['AWS_SECRET_KEY']
+    delete newValidManifest['private']
+    newValidManifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY'] = 'AWS_SECRET_KEY'
+    const result = generateManifest(varsMock, manifestMock)
+    return expect(result).to.eventually.become(newValidManifest)
+  })
+
+  it('should add manifest.vars field to final manifest if vars are defined in codiusvars but not in codius', async function () {
+    const manifest = JSON.parse(JSON.stringify(manifestJson))
+    delete manifest['manifest']['vars']
+    await fse.writeJson(manifestMock, manifest)
+    const result = generateManifest(varsMock, manifestMock)
+    return expect(result).to.eventually.become(validManifest)
+  })
+
+  /*
   it('should produce an error if a container contains an invalid image', async function () {
     const manifest = JSON.parse(JSON.stringify(manifestJson))
     manifest['manifest']['containers'][0]['image'] = 'hello-world@1231984'
@@ -108,4 +185,5 @@ describe('Generate Complete Manifest', function () {
     validManifest['manifest']['containers'][0]['image'] = `nginx@sha256:0946416199aca5c7bd2c3173f8a909b0873e9017562f1a445d061fce6664a049`
     return expect(result).to.eventually.become(validManifest)
   })
+  */
 })

--- a/test/generate-manifest.test.js
+++ b/test/generate-manifest.test.js
@@ -114,7 +114,7 @@ describe('Generate Complete Manifest', function () {
     return expect(result).to.eventually.become(newValidManifest)
   })
 
-  it('should add an empty private var field to the final manifest if the addEmptyPrivateVars option is specified and the public vars are not defined', async function () {
+  it('should add an empty private var field to the final manifest if the public vars are defined', async function () {
     const manifest = JSON.parse(JSON.stringify(manifestJson))
     delete manifest['manifest']['vars']['AWS_SECRET_KEY']
     delete manifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY']
@@ -129,8 +129,7 @@ describe('Generate Complete Manifest', function () {
     newValidManifest['private'] = {}
     delete newValidManifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY']
     delete newValidManifest['manifest']['vars']['AWS_SECRET_KEY']
-    const options = { addEmptyPrivateVars: true }
-    const result = generateManifest(varsMock, manifestMock, options)
+    const result = generateManifest(varsMock, manifestMock)
     return expect(result).to.eventually.become(newValidManifest)
   }
 
@@ -151,24 +150,6 @@ describe('Generate Complete Manifest', function () {
     delete newValidManifest['manifest']['vars']['AWS_ACCESS_KEY']
     newValidManifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY'] = '$AWS_SECRET_KEY'
     newValidManifest['manifest']['containers'][0]['environment']['AWS_ACCESS_KEY'] = 'AWS_ACCESS_KEY'
-    const result = generateManifest(varsMock, manifestMock)
-    return expect(result).to.eventually.become(newValidManifest)
-  })
-
-  it('should leave out private vars field from final manifest if private vars are not defined in codiusvars', async function () {
-    const manifest = JSON.parse(JSON.stringify(manifestJson))
-    manifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY'] = 'AWS_SECRET_KEY'
-    delete manifest['manifest']['vars']['AWS_SECRET_KEY']
-    await fse.writeJson(manifestMock, manifest)
-
-    const vars = JSON.parse(JSON.stringify(varsJson))
-    vars['vars']['private'] = {}
-    await fse.writeJson(varsMock, vars)
-
-    const newValidManifest = JSON.parse(JSON.stringify(validManifest))
-    delete newValidManifest['manifest']['vars']['AWS_SECRET_KEY']
-    delete newValidManifest['private']
-    newValidManifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY'] = 'AWS_SECRET_KEY'
     const result = generateManifest(varsMock, manifestMock)
     return expect(result).to.eventually.become(newValidManifest)
   })

--- a/test/mocks/codiusvars.test.json
+++ b/test/mocks/codiusvars.test.json
@@ -7,7 +7,6 @@
     },
     "private": {
       "AWS_SECRET_KEY": {
-        "nonce": "123450325",
         "value": "AKRTP2SB9AF5TQQ1N1BC"
       }
     }


### PR DESCRIPTION
This PR includes four major changes:
1. Nonce values may no longer be specified in codiusvars.json for private variables. Nonce values and public encodings for private variables are now generated automatically with the final manifest.
2. If public or private variables are not specified in codiusvars.json, then the corresponding vars fields will not be included in the generated manifest.
3. The image digest validation feature is temporarily disabled until dependency vulnerabilities are resolved.
4. The generate manifest function has been refactored to enhance readability and organization.