### PR TITLE
Vt allow undefined env field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codius-manifest",
-  "version": "1.0.0",
+  "version": "2.0.3",
   "description": "A module for validating Codius manifests",
   "main": "index.js",
   "scripts": {

--- a/src/common/check-usage.js
+++ b/src/common/check-usage.js
@@ -8,7 +8,9 @@ const checkUsage = function (manifest, varName) {
   for (let i = 0; i < containers.length; i++) {
     const container = containers[i]
     const envVars = container['environment']
-
+    if (!envVars) {
+      continue
+    }
     // Check if there is a key that corresponds to the variable name
     if (envVars['varName']) {
       return true

--- a/src/validate-containers.js
+++ b/src/validate-containers.js
@@ -13,6 +13,9 @@ const validateContainers = function (manifest) {
   for (let i = 0; i < containers.length; i++) {
     const environment = manifest['manifest']['containers'][i]['environment']
     debug(`environment: ${JSON.stringify(environment, null, 2)}`)
+    if (!environment) {
+      continue
+    }
     // Error check each environment key
     const environmentKeys = Object.keys(environment)
     environmentKeys.map((varName) => {

--- a/test/generate-manifest.test.js
+++ b/test/generate-manifest.test.js
@@ -162,6 +162,26 @@ describe('Generate Complete Manifest', function () {
     return expect(result).to.eventually.become(validManifest)
   })
 
+  it('should not throw an error the environment and vars fields are undefined', async function () {
+    const manifest = JSON.parse(JSON.stringify(manifestJson))
+    delete manifest['manifest']['containers'][0]['environment']
+    delete manifest['manifest']['vars']
+    await fse.writeJson(manifestMock, manifest)
+    console.log(manifest)
+
+    const vars = JSON.parse(JSON.stringify(varsJson))
+    vars['vars']['public'] = {}
+    vars['vars']['private'] = {}
+    console.log(vars)
+    await fse.writeJson(varsMock, vars)
+
+    const newValidManifest = JSON.parse(JSON.stringify(validManifest))
+    delete newValidManifest['manifest']['vars']
+    delete newValidManifest['private']
+    delete newValidManifest['manifest']['containers'][0]['environment']
+    const result = generateManifest(varsMock, manifestMock)
+    return expect(result).to.eventually.become(newValidManifest)
+  })
   /*
   it('should produce an error if a container contains an invalid image', async function () {
     const manifest = JSON.parse(JSON.stringify(manifestJson))
@@ -171,6 +191,7 @@ describe('Generate Complete Manifest', function () {
     return expect(result).to.be.rejected
   })
 
+  // Relies upon response from docker registry api to pass
   it('should resolve image tags to proper digest', async function () {
     const manifest = JSON.parse(JSON.stringify(manifestJson))
     manifest['manifest']['containers'][0]['image'] = 'nginx:1.15.0'

--- a/test/validate-private-vars.test.js
+++ b/test/validate-private-vars.test.js
@@ -37,7 +37,14 @@ describe('Validate Private Manifest Variables', function () {
 
   it('should return errors if a private variable is never used in a container', function () {
     delete manifest['manifest']['containers'][0]['environment']['AWS_SECRET_KEY']
-
+    const result = validatePrivateVars(manifest, 0)
+    const expected = [{ 'private.AWS_SECRET_KEY':
+    'private var is never used within a container'
+    }]
+    expect(result).to.deep.equal(expected)
+  })
+  it('should return errors if private vars are defined but there are no environment fields in the containers', function () {
+    delete manifest['manifest']['containers'][0]['environment']
     const result = validatePrivateVars(manifest, 0)
     const expected = [{ 'private.AWS_SECRET_KEY':
     'private var is never used within a container'

--- a/test/validate-public-vars.test.js
+++ b/test/validate-public-vars.test.js
@@ -29,4 +29,12 @@ describe('Validate Public Manifest Variables', function () {
     }]
     expect(result).to.deep.equal(expected)
   })
+  it('should return errors if public vars are defined but are no container environment fields', function () {
+    let containers = manifest['manifest']['containers']
+    delete containers[0]['environment']
+    const result = validatePublicVars(manifest)
+    const expected = [{ 'manifest.vars.AWS_ACCESS_KEY': 'public var is not used within a container' },
+      { 'manifest.vars.AWS_SECRET_KEY': 'public var is not used within a container' }]
+    expect(result).to.deep.equal(expected)
+  })
 })


### PR DESCRIPTION
This PR allows manifests without both environment fields and public/private var fields to pass validation.