### PR TITLE
vt fix: remove empty environment fields from final manifest

### DIFF
--- a/src/generate-manifest.js
+++ b/src/generate-manifest.js
@@ -24,6 +24,7 @@ const generateManifest = async function (codiusVarsPath, codiusPath) {
   const generatedManifest = { manifest: codius['manifest'] }
   processPublicVars(generatedManifest, codiusVars)
   processPrivateVars(generatedManifest, codiusVars)
+  removeEmptyEnvironments(generatedManifest)
   removeDescriptions(generatedManifest)
 
   // Validate generated manifest
@@ -116,6 +117,20 @@ const processPrivateVars = function (generatedManifest, codiusVars) {
   // Add private vars to final manifest
   generatedManifest['private'] = { vars: privateVars }
   addPrivateVarEncodings(generatedManifest)
+}
+
+const removeEmptyEnvironments = function (generatedManifest) {
+  // Remove empty environment fields from containers
+  const containers = generatedManifest['manifest']['containers']
+  containers.map((container) => {
+    const environment = container['environment']
+    if (environment) {
+      const envVars = Object.keys(environment)
+      if (envVars.length < 1) {
+        delete container['environment']
+      }
+    }
+  })
 }
 
 const addPrivateVarEncodings = function (generatedManifest) {

--- a/test/generate-manifest.test.js
+++ b/test/generate-manifest.test.js
@@ -162,6 +162,44 @@ describe('Generate Complete Manifest', function () {
     return expect(result).to.eventually.become(validManifest)
   })
 
+  it('should not throw an error if the environment and vars fields are undefined', async function () {
+    const manifest = JSON.parse(JSON.stringify(manifestJson))
+    delete manifest['manifest']['containers'][0]['environment']
+    delete manifest['manifest']['vars']
+    await fse.writeJson(manifestMock, manifest)
+
+    const vars = JSON.parse(JSON.stringify(varsJson))
+    vars['vars']['public'] = {}
+    vars['vars']['private'] = {}
+    await fse.writeJson(varsMock, vars)
+
+    const newValidManifest = JSON.parse(JSON.stringify(validManifest))
+    delete newValidManifest['manifest']['vars']
+    delete newValidManifest['private']
+    delete newValidManifest['manifest']['containers'][0]['environment']
+    const result = generateManifest(varsMock, manifestMock)
+    return expect(result).to.eventually.become(newValidManifest)
+  })
+
+  it('should remove empty environment fields from containers in final manifest', async function () {
+    const manifest = JSON.parse(JSON.stringify(manifestJson))
+    manifest['manifest']['containers'][0]['environment'] = {}
+    delete manifest['manifest']['vars']
+    await fse.writeJson(manifestMock, manifest)
+
+    const vars = JSON.parse(JSON.stringify(varsJson))
+    vars['vars']['public'] = {}
+    vars['vars']['private'] = {}
+    await fse.writeJson(varsMock, vars)
+
+    const newValidManifest = JSON.parse(JSON.stringify(validManifest))
+    delete newValidManifest['manifest']['vars']
+    delete newValidManifest['private']
+    delete newValidManifest['manifest']['containers'][0]['environment']
+    const result = generateManifest(varsMock, manifestMock)
+    return expect(result).to.eventually.become(newValidManifest)
+  })
+
   /*
   it('should produce an error if a container contains an invalid image', async function () {
     const manifest = JSON.parse(JSON.stringify(manifestJson))

--- a/test/validate-public-vars.test.js
+++ b/test/validate-public-vars.test.js
@@ -29,4 +29,13 @@ describe('Validate Public Manifest Variables', function () {
     }]
     expect(result).to.deep.equal(expected)
   })
+
+  it('should return errors if public vars are defined but there are no environment fields', function () {
+    let containers = manifest['manifest']['containers']
+    delete containers[0]['environment']
+    const result = validatePublicVars(manifest)
+    const expected = [{ 'manifest.vars.AWS_ACCESS_KEY': 'public var is not used within a container' },
+      { 'manifest.vars.AWS_SECRET_KEY': 'public var is not used within a container' }]
+    expect(result).to.deep.equal(expected)
+  })
 })


### PR DESCRIPTION
This pull request removes empty environment fields from the final manifest, and adds test coverage for manifests with empty environment fields.