### PR TITLE
feat: support manifest environment interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,30 @@ Manifests that are valid against the standard schema are considered complete.
   }
 }
 ```
+## Simple Manifest
+A simple manifest has the environment fields fully interpolated, with the public and private
+variable fields removed.
+
+```json
+{
+  "manifest": {
+    "name": "my-codius-pod",
+    "version": "1.0.0",
+    "machine": "small",
+    "port": " 8080",
+    "containers": [{
+      "id": "app",
+      "image": "hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77",
+      "command": ["/bin/sh"],
+      "workdir": "/root",
+      "environment": {
+        "AWS_ACCESS_KEY": "AKRTP2SB9AF5TQQ1N1BB",
+        "AWS_SECRET_KEY": "AKRTP2SB9AF5TQQ1N1BC"
+      }
+    }]
+  }
+}
+```
 
 ## Codius Files
 Manifests are generated from two files: `codius.json` and `codiusvars.json`.
@@ -165,6 +189,16 @@ Arguments:
   * Description: the manifest to be hashed
 
 The function returns the `sha256` manifest hash with `base32` encoding.
+
+### `generateSimpleManifest(manifest)`
+Generates a manifest with the container environment fields interpolated.
+
+Arguments:
+* `manifest`
+  * Type: JSON
+  * Description: the manifest to be interpolated
+
+The function returns a JSON object representing the interpolated manifest, with the public and private variable fields removed.
 
 ## Usage
 The module can be used to easily generate manifest files.

--- a/index.js
+++ b/index.js
@@ -2,8 +2,10 @@
 const { validateGeneratedManifest } = require('./src/validate-generated-manifest.js')
 const { hashManifest } = require('./src/common/crypto-utils.js')
 const { generateManifest } = require('./src/generate-manifest.js')
+const { generateSimpleManifest } = require('./src/generate-simple-manifest.js')
 module.exports = {
   validateGeneratedManifest,
   generateManifest,
-  hashManifest
+  hashManifest,
+  generateSimpleManifest
 }

--- a/src/generate-manifest.js
+++ b/src/generate-manifest.js
@@ -85,20 +85,15 @@ const processPublicVars = function (generatedManifest, codiusVars) {
   // Update public vars in the final manifest
   const publicVars = codiusVars['vars']['public'] || {}
   const publicVarKeys = Object.keys(publicVars)
-
   // Check if public vars are specified in codiusvars
   if (publicVarKeys.length < 1) {
     return
   }
 
+  // Add public vars to manifest vars
   const manifest = generatedManifest['manifest']
   const manifestVars = manifest['vars']
-  // Add public vars to manifest vars
-  if (manifest['vars']) {
-    manifest['vars'] = { ...manifestVars, ...publicVars }
-  } else {
-    manifest['vars'] = publicVars
-  }
+  manifest['vars'] = manifestVars ? { ...manifestVars, ...publicVars } : publicVars
 }
 
 const processPrivateVars = function (generatedManifest, codiusVars) {

--- a/src/generate-simple-manifest.js
+++ b/src/generate-simple-manifest.js
@@ -1,0 +1,55 @@
+const { validateGeneratedManifest } = require('./validate-generated-manifest.js')
+
+const generateSimpleManifest = function (manifest) {
+  // This function generates a simplified manifest with the container
+  // environment fields fully interpolated
+
+  const manifestErrors = validateGeneratedManifest(manifest)
+  if (manifestErrors.length) {
+    throw new Error(`Invalid manifest. errors=${JSON.stringify(manifestErrors, null, 2)}`)
+  }
+  const simpleManifest = {
+    manifest: {
+      name: manifest['manifest']['name'],
+      version: manifest['manifest']['version'],
+      machine: manifest['manifest']['machine'],
+      containers: deepcopy(manifest['manifest']['containers'])
+    }
+  }
+
+  const simpleContainers = simpleManifest['manifest']['containers']
+  simpleContainers.map((container) => {
+    processContainer(manifest, container)
+  })
+  return simpleManifest
+}
+
+const processContainer = function (manifest, container) {
+  const environment = container['environment']
+  if (!environment) {
+    return
+  }
+
+  Object.keys(environment).map((key) => {
+    const value = environment[key]
+    if (!value.startsWith('$')) {
+      return
+    }
+    const varSpec = manifest['manifest']['vars'][key]
+    if (!varSpec.encoding) {
+      environment[key] = varSpec.value
+      return
+    }
+
+    const privateVarSpec = manifest['private']['vars'][key]
+    environment[key] = privateVarSpec.value
+  })
+}
+
+const deepcopy = function (obj) {
+  return JSON.parse(JSON.stringify(obj))
+}
+
+module.exports = {
+  generateSimpleManifest
+}

--- a/src/validate-generated-manifest.js
+++ b/src/validate-generated-manifest.js
@@ -16,11 +16,14 @@ const validateGeneratedManifest = function (manifest) {
     return schemaErrors
   }
 
-  errors = errors.concat(
-    validateContainers(manifest),
-    validatePublicVars(manifest),
-    validatePrivateVars(manifest)
-  )
+  const containerErrors = validateContainers(manifest)
+  const publicVarErrors = validatePublicVars(manifest)
+  const privateVarErrors = validatePrivateVars(manifest)
+  errors = [
+    ...containerErrors,
+    ...publicVarErrors,
+    ...privateVarErrors
+  ]
   debug(`manifest errors: ${JSON.stringify(errors, null, 2)}`)
   return errors
 }

--- a/src/validate-schema.js
+++ b/src/validate-schema.js
@@ -1,4 +1,4 @@
-const addErrorMessage = require('./common/add-error.js').addErrorMessage
+const { addErrorMessage } = require('./common/add-error.js')
 const debug = require('debug')('codius-manifest:validate-schema')
 const jsen = require('jsen')
 const generatedManifestSpec = require('../schemas/GeneratedManifestSpec.json')

--- a/test/generate-manifest.test.js
+++ b/test/generate-manifest.test.js
@@ -241,5 +241,5 @@ describe('Generate Complete Manifest', function () {
     const result = generateManifest(varsMock, manifestMock)
     validManifest['manifest']['containers'][0]['image'] = `nginx@sha256:0946416199aca5c7bd2c3173f8a909b0873e9017562f1a445d061fce6664a049`
     return expect(result).to.eventually.become(validManifest)
-  })
+  }).timeout(3000)
 })

--- a/test/generate-simple-manifest.test.js
+++ b/test/generate-simple-manifest.test.js
@@ -1,0 +1,44 @@
+/* eslint-env mocha */
+const { expect } = require('chai')
+const { generateSimpleManifest } = require('../src/generate-simple-manifest.js')
+const testManifest = JSON.stringify(require('./mocks/manifest.test.json'))
+const testSimpleManifest = JSON.stringify(require('./mocks/simple-manifest.test.json'))
+
+describe('Generate Simple Manifest', function () {
+  let manifest
+  let simpleManifest
+
+  beforeEach(function () {
+    manifest = JSON.parse(testManifest)
+    simpleManifest = JSON.parse(testSimpleManifest)
+  })
+
+  it('should generate correct simple manifest if original manifest is valid', function () {
+    const result = generateSimpleManifest(manifest)
+    expect(simpleManifest).to.deep.equal(result)
+  })
+
+  it('should skip interpolation if manifest has no environment fields', function () {
+    delete manifest['manifest']['vars']
+    delete manifest['private']
+    delete manifest['manifest']['containers'][0]['environment']
+    delete simpleManifest['manifest']['containers'][0]['environment']
+
+    const result = generateSimpleManifest(manifest)
+    expect(simpleManifest).to.deep.equal(result)
+  })
+
+  it('should throw error if manifest has schema errors', function () {
+    delete manifest['manifest']['name']
+    expect(() => {
+      generateSimpleManifest(manifest)
+    }).to.throw()
+  })
+
+  it('should properly interpolate literals within container environments', function () {
+    manifest['manifest']['containers'][0]['environment']['ENV_LITERAL'] = 'ENV_LITERAL'
+    simpleManifest['manifest']['containers'][0]['environment']['ENV_LITERAL'] = 'ENV_LITERAL'
+    const result = generateSimpleManifest(manifest)
+    expect(simpleManifest).to.deep.equal(result)
+  })
+})

--- a/test/mocks/simple-manifest.test.json
+++ b/test/mocks/simple-manifest.test.json
@@ -1,0 +1,17 @@
+{
+  "manifest": {
+    "name": "my-codius-pod",
+    "version": "1.0.0",
+    "machine": "small",
+    "containers": [{
+      "id": "app",
+      "image": "hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77",
+      "command": ["/bin/sh"],
+      "workdir": "/root",
+      "environment": {
+        "AWS_ACCESS_KEY": "AKRTP2SB9AF5TQQ1N1BB",
+        "AWS_SECRET_KEY": "AKRTP2SB9AF5TQQ1N1BC"
+      }
+    }]
+  }
+}

--- a/test/validate-containers.test.js
+++ b/test/validate-containers.test.js
@@ -11,8 +11,8 @@ describe('Validate Containers in Manifest', function () {
   })
 
   it('should not return errors if containers in manifest are valid', function () {
-    const result = validateContainers(manifest)
-    expect(result).to.deep.equal([])
+    const errors = validateContainers(manifest)
+    expect(errors).to.deep.equal([])
   })
 
   it('should return errors if there are issues with multiple containers', function () {
@@ -32,14 +32,14 @@ describe('Validate Containers in Manifest', function () {
     // Insert environment variable without adding it to manifest.vars
     let environment = manifest['manifest']['containers'][0]['environment']
     environment['ENV_VAR'] = '$ENV_VAR'
-    const result = validateContainers(manifest)
+    const errors = validateContainers(manifest)
     const expected = [
       { 'manifest.containers[0].environment.ENV_VAR':
       'env variable is not defined within manifest.vars.' },
       { 'manifest.containers[1].environment.CODIUS_HOST':
       'environment variables starting in `CODIUS` are reserved.' }
     ]
-    expect(result).to.deep.equal(expected)
+    expect(errors).to.deep.equal(expected)
   })
 
   it('should return errors if env variable names begin with "CODIUS"', function () {
@@ -47,22 +47,20 @@ describe('Validate Containers in Manifest', function () {
     environment['CODIUS_VAR'] = '$CODIUS_VAR'
     manifest['manifest']['vars']['CODIUS_VAR'] = {'value': 'CODIUS_VAR'}
     manifest['private']['vars']['CODIUS_VAR'] = {'nonce': '1242352353', 'value': ''}
-
-    const result = validateContainers(manifest)
+    const errors = validateContainers(manifest)
     const expected = [{ 'manifest.containers[0].environment.CODIUS_VAR':
     'environment variables starting in `CODIUS` are reserved.'
     }]
-    expect(result).to.deep.equal(expected)
+    expect(errors).to.deep.equal(expected)
   })
 
   it('should return errors if env variable is not defined in manifest.vars', function () {
     let environment = manifest['manifest']['containers'][0]['environment']
     environment['ENV_VAR'] = '$ENV_VAR'
-
-    const result = validateContainers(manifest)
+    const errors = validateContainers(manifest)
     const expected = [{ 'manifest.containers[0].environment.ENV_VAR':
     'env variable is not defined within manifest.vars.' }]
-    expect(result).to.deep.equal(expected)
+    expect(errors).to.deep.equal(expected)
   })
 
   it('should return errors if encoded env variables are not defined in private manifest', function () {
@@ -71,18 +69,17 @@ describe('Validate Containers in Manifest', function () {
     manifest['manifest']['vars']['ENV_VAR'] = {
       'encoding': 'private:sha256',
       'value': '95b3449d5b13a4e60e5c0' }
-
-    const result = validateContainers(manifest)
+    const errors = validateContainers(manifest)
     const expected = [{ 'manifest.containers[0].environment.ENV_VAR':
     'encoded env variable is not defined within private manifest field' }]
-    expect(result).to.deep.equal(expected)
+    expect(errors).to.deep.equal(expected)
   })
 
   it('should return errors if two containers have the same id', function () {
     let containers = manifest['manifest']['containers']
     containers.push(manifest['manifest']['containers'][0])
-    const result = validateContainers(manifest)
+    const errors = validateContainers(manifest)
     const expected = [{ 'manifest.containers': 'container ids must be unique.' }]
-    expect(result).to.deep.equal(expected)
+    expect(errors).to.deep.equal(expected)
   })
 })

--- a/test/validate-generated-manifest.test.js
+++ b/test/validate-generated-manifest.test.js
@@ -11,8 +11,8 @@ describe('Validate Entire Manifest', function () {
   })
 
   it('should not return errors if manifest is valid', function () {
-    const result = validateGeneratedManifest(manifest)
-    expect(result).to.deep.equal([])
+    const errors = validateGeneratedManifest(manifest)
+    expect(errors).to.deep.equal([])
   })
 
   it('should return proper errors if spec errors occur', function () {
@@ -20,11 +20,11 @@ describe('Validate Entire Manifest', function () {
     let environment = manifest['manifest']['containers'][0]['environment']
     environment['CODIUS_VAR'] = '$CODIUS_VAR'
     manifest['manifest']['vars']['CODIUS_VAR'] = {'value': ''}
-    const result = validateGeneratedManifest(manifest)
+    const errors = validateGeneratedManifest(manifest)
     const expected = [
       { 'manifest.containers[0].environment.CODIUS_VAR': 'environment variables starting in `CODIUS` are reserved.' }
     ]
-    expect(result).to.deep.equal(expected)
+    expect(errors).to.deep.equal(expected)
   })
 
   it('should only return schema errors if both schema and spec errors occur', function () {
@@ -36,21 +36,21 @@ describe('Validate Entire Manifest', function () {
     environment['CODIUS_VAR'] = '$CODIUS_VAR'
     manifest['manifest']['vars']['CODIUS_VAR'] = {'value': ''}
 
-    const result = validateGeneratedManifest(manifest)
+    const errors = validateGeneratedManifest(manifest)
     const expected = [
       { 'manifest.name': "schema is invalid. error={'path':'manifest.name','keyword':'required'}" }
     ]
-    expect(result).to.deep.equal(expected)
+    expect(errors).to.deep.equal(expected)
   })
 
   it('should return proper errors if public env vars are not defined', function () {
     delete manifest['manifest']['vars']
-    const result = validateGeneratedManifest(manifest)
+    const errors = validateGeneratedManifest(manifest)
     const expected = [
       { 'manifest.containers[0].environment.AWS_ACCESS_KEY': 'cannot validate env variable - manifest.vars not defined' },
       { 'manifest.containers[0].environment.AWS_SECRET_KEY': 'cannot validate env variable - manifest.vars not defined' },
       { 'private': 'cannot validate private vars - manifest.vars is not defined.' }
     ]
-    expect(result).to.deep.equal(expected)
+    expect(errors).to.deep.equal(expected)
   })
 })


### PR DESCRIPTION
This PR updates the manifest module to export `generateSimpleManifest`, which interpolates the environment fields for each container in a manifest. The environment fields are swapped in with their literal values, and the public and private variable fields are removed from the manifest. This feature is meant to be used by [codiusd](https://github.com/codius/codiusd) to generate the hyperd pod spec.