### PR TITLE
fix: bug fixes for docker image resolution

### DIFF
--- a/src/resolve-image.js
+++ b/src/resolve-image.js
@@ -82,9 +82,10 @@ const getManifestResp = async function (image, token) {
     const registryUrl = getRegistryUrl(image)
 
     // Build url for manifest request - see https://docs.docker.com/registry/spec/api/
-    let manifestUrl = `${registryUrl}${namespace || 'library'}/${repository}/manifests/${tag}`
+    let manifestUrl = `${registryUrl}${namespace || 'library'}/${repository}/manifests/${tag || 'latest'}`
     debug(`fetching manifest info from registry manifest endpoint. manifestUrl=${manifestUrl} manifestOptions=${JSON.stringify(manifestOptions, null, 2)}`)
-    return await axios.get(manifestUrl, manifestOptions)
+    const { data, headers } = await axios.get(manifestUrl, manifestOptions)
+    return { data, headers }
   } catch (err) {
     debug(err)
     throw new Error('Unable to get manifest info from registry.')


### PR DESCRIPTION
This PR fixes two bugs in the existing docker image resolution code:
1. In the current code, the full response from the docker registry manifest endpoint is included in the debug logs. This response may include circular fields that cannot be stringified.  Instead of logging the full response, this PR will only include relevant data fields from the docker registry response in the debug output.
2. The existing code will throw an error for images that do not have a tag, e.g., nginx or centos. This PR appends the tag `latest` to the image before resolving to a digest, which fixes the issue.